### PR TITLE
enforse use of v1.0 for the paper

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -1,7 +1,7 @@
 # Install dualsimplex package
 library(devtools)
 unloadNamespace("dualsimplex")
-devtools::install_github("artyomovlab/DualSimplex")
+devtools::install_github("artyomovlab/DualSimplex@v1.0")
 #devtools::load_all("../../dualsimplex") to install from local directory
 library(DualSimplex)
 options("dualsimplex-rasterize" = T)


### PR DESCRIPTION
Since development continues I have added release version with the paper version to the main repository